### PR TITLE
Allow deep recursion

### DIFF
--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -73,9 +73,9 @@ def get_files_from_dir(current_dir):
             if len(file_split) == 2 and file_split[0] != "" \
                     and file_split[1] == '.py':
                 files.append(file_path)
-        elif os.path.isdir(dir_file) and dir_file not in IGNORE_FOLDERS:
-            path = dir_file+"/"
+        elif (os.path.isdir(dir_file) or os.path.isdir(file_path)) and dir_file not in IGNORE_FOLDERS:
+            path = dir_file + "/"
             if current_dir != "" and current_dir != ".":
-                path = current_dir.rstrip("/")+"/"+path
+                path = current_dir.rstrip("/") + "/" + path
             files += get_files_from_dir(path)
     return files

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -73,7 +73,8 @@ def get_files_from_dir(current_dir):
             if len(file_split) == 2 and file_split[0] != "" \
                     and file_split[1] == '.py':
                 files.append(file_path)
-        elif (os.path.isdir(dir_file) or os.path.isdir(file_path)) and dir_file not in IGNORE_FOLDERS:
+        elif (os.path.isdir(dir_file) or os.path.isdir(file_path))\
+                and dir_file not in IGNORE_FOLDERS:
             path = dir_file + "/"
             if current_dir != "" and current_dir != ".":
                 path = current_dir.rstrip("/") + "/" + path


### PR DESCRIPTION
Previously the runner would only find files UP TO 1 level deep.
Meaning with the following tree:
```
├── Dockerfile
├── README.md
├── apps
│   ├── __init__.py
│   ├── administration
│   │   ├── models.py
│   │   ├── tests.py
│   │   ├── urls.py
│   │   └── views.py
│   ├── marketing
│   │   ├── models.py
│   │   ├── tests.py
│   │   ├── urls.py
│   │   └── views.py
└── utils
    ├── __init__.py
    ├── fields.py
    └── models.py
```

The only files that would be found are:

* apps/\_\_init\_\_.py
* utils/\_\_init\_\_.py
* utils/fields.py
* utils/models.py

With this fix, all files will be found.

Also fixed some minor flake8 spacing suggestions.

Fixes #3