### PR TITLE
Add command line arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# History
+
+## 0.4.0
+
+Tuesday, February 14, 2017
+
+* Refactored module into class to facilitate easy argument loading
+* Added verbose mode and defaulted to off
+* Added the ability to specify a pylintrc file (defaults to `.pylintrc` relative to calling location)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#pylint_runner
+# pylint_runner
 [![Build Status](https://travis-ci.org/MasterOdin/pylint_runner.svg?branch=master)](https://travis-ci.org/MasterOdin/pylint_runner)
 [![Coverage Status](https://coveralls.io/repos/MasterOdin/pylint_runner/badge.svg?branch=master)](https://coveralls.io/r/MasterOdin/pylint_runner?branch=master)
-[![Latest Version](https://pypip.in/version/pylint_runner/badge.svg?text=pypi)](https://pypi.python.org/pypi/pylint_runner/)
-[![Supported Python versions](https://pypip.in/py_versions/pylint_runner/badge.svg)](https://pypi.python.org/pypi/pylint_runner/)
-[![License](https://pypip.in/license/pylint_runner/badge.svg)](https://pypi.python.org/pypi/pylint_runner/)
+[![PyPI version](https://badge.fury.io/py/pylint_runner.svg)](https://badge.fury.io/py/pylint_runner)
+[![Supported Python versions](https://img.shields.io/badge/python%20version-2.6%2B%2C%203.2%2B-brightgreen.svg)](https://pypi.python.org/pypi/pylint_runner/)
+[![License](https://img.shields.io/github/license/MasterOdin/pylint_runner.svg)](https://pypi.python.org/pypi/pylint_runner/)
 
-A simple pylint application that runs scans the current directory and any sub-directories recursively, then runs pylint on all discovered .py files.
+A simple pylint application that scans the current directory and any sub-directories recursively, then runs pylint on all discovered `.py` files.
 
-##Installation
+## Installation
 Dependencies:  
 * [colorama](https://pypi.python.org/pypi/colorama)  
 * [pylint](http://www.pylint.org/)  
@@ -23,29 +23,62 @@ From source:
 python setup.py install
 ```
 
-##Usage
-```
+## Usage
+
+```shell
 pylint_runner
 ```
 
-This will generate (if run against this repo):  
-```
-Using pylint 1.4.1 for python 2.7.8  
-pylint running on the following files:
-- ./pylint_runner/__init__.py
-- ./pylint_runner/main.py
-- ./setup.py
-- ./tests/__init__.py
-- ./tests/test_runner.py
-----
-No config file found, using default configuration
-```
+Output is standard pylint output. There should be no output if no issues were found.
 
-If there were any issues, the following would be attached to the above print:
+In case of issues, you should see output similar to:
+
 ```
 ************* Module pylint_runner.main
 C: 24, 0: Missing function docstring (missing-docstring)
 ************* Module tests.test_runner
 C: 19, 0: Final newline missing (missing-final-newline)
 C: 19, 0: Invalid constant name "a" (invalid-name)
+```
+
+### Additional Arguments
+
+See the standard help ouput:
+
+```shell
+pylint_runner -h
+```
+
+#### Verbose mode
+
+```shell
+pylint_runner -v
+```
+Verbose mode lists all files that were found for testing immediately, along with the pylint output.
+
+This will generate (if run against this repo): 
+ 
+```
+Using pylint 1.6.5 for python 2.7.11
+pylint running on the following files:
+- pylint_runner/__init__.py
+- pylint_runner/main.py
+- setup.py
+- tests/__init__.py
+- tests/test_runner.py
+- tests/tests/dummy.py
+----
+************* Module tests.test_runner
+I:  1, 0: Locally disabling missing-docstring (C0111) (locally-disabled)
+```
+
+#### --rcfile path\_to\_file
+
+This allows you to specify a pylintrc file to be used.
+
+It may be a relative, or absolute path and defaults to `.pylintrc` at the current working directory.
+
+It will read the value of `ignore` from the rcfile and ignore any matching files/folders while building the list of files to pass to python.
+
+It will also pass that rcfile for use by pylint.
 ```

--- a/README.md
+++ b/README.md
@@ -81,4 +81,3 @@ It may be a relative, or absolute path and defaults to `.pylintrc` at the curren
 It will read the value of `ignore` from the rcfile and ignore any matching files/folders while building the list of files to pass to python.
 
 It will also pass that rcfile for use by pylint.
-```

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -117,7 +117,8 @@ class Runner(object):
                 if len(file_split) == 2 and file_split[0] != "" \
                         and file_split[1] == '.py':
                     files.append(file_path)
-            elif (os.path.isdir(dir_file) or os.path.isdir(file_path)) and dir_file not in self.ignore_folders:
+            elif (os.path.isdir(dir_file) or os.path.isdir(file_path))\
+                    and dir_file not in self.ignore_folders:
                 path = dir_file + "/"
                 if current_dir != "" and current_dir != ".":
                     path = current_dir.rstrip("/") + "/" + path

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -1,81 +1,164 @@
 #!/usr/bin/env python
-# pylint: disable=no-member
 """
 Runs pylint on all contained python files in this directory, printint out
 nice colorized warnings/errors without all the other report fluff
 """
 from __future__ import print_function
+
 import os
 import sys
+from argparse import ArgumentParser
+import configparser
+
 import colorama
 import pylint
 import pylint.lint
 
-
 __author__ = "Matthew 'MasterOdin' Peveler"
 __license__ = "The MIT License (MIT)"
 
-IGNORE_FOLDERS = [".git", ".idea", "__pycache__"]
-ARGS = ["--reports=n", "--output-format=colorized", "--disable=locally-disabled"]
 
-colorama.init(autoreset=True)
+class Runner(object):
+    """ A pylint runner that will lint all files recursively from the CWD. """
+
+    DEFAULT_IGNORE_FOLDERS = [".git", ".idea", "__pycache__"]
+    DEFAULT_ARGS = ["--reports=n", "--output-format=colorized"]
+    DEFAULT_RCFILE = '.pylintrc'
+
+    def __init__(self, args=None):
+        colorama.init(autoreset=True)
+
+        self.verbose = False
+        self.args = self.DEFAULT_ARGS
+        self.rcfile = self.DEFAULT_RCFILE
+        self.ignore_folders = self.DEFAULT_IGNORE_FOLDERS
+
+        self._parse_args(args or sys.argv[1:])
+        self._parse_ignores()
+
+    def _parse_args(self, args):
+        """Parses any supplied command-line args and provides help text. """
+
+        parser = ArgumentParser(description='Runs pylint recursively on a directory')
+
+        parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', default=False,
+                            help='Verbose mode (report which files were found for testing).')
+
+        parser.add_argument('--rcfile', dest='rcfile', action='store', default='.pylintrc',
+                            help='A relative or absolute path to your pylint rcfile. Defaults to\
+                            `.pylintrc` at the current working directory')
+
+        options, _unknown = parser.parse_known_args(args)
+
+        self.verbose = options.verbose
+
+        if options.rcfile:
+            if not os.path.isfile(options.rcfile):
+                options.rcfile = os.getcwd() + '/' + options.rcfile
+            self.rcfile = options.rcfile
+
+        return options
+
+    def _parse_ignores(self):
+        """ Parse the ignores setting from the pylintrc file if available. """
+
+        error_message = (
+            colorama.Fore.RED +
+            '{} does not appear to be a valid pylintrc file'.format(self.rcfile) +
+            colorama.Fore.RESET
+        )
+
+        if not os.path.isfile(self.rcfile):
+            if not self._is_using_default_rcfile():
+                print(error_message)
+                sys.exit(1)
+            else:
+                return
+
+        config = configparser.ConfigParser()
+        try:
+            with open(self.rcfile) as configfile:
+                config.read_file(configfile)
+        except configparser.MissingSectionHeaderError:
+            print(error_message)
+            sys.exit(1)
+
+        if config.has_section('MASTER') and config['MASTER'].get('ignore'):
+            self.ignore_folders += config['MASTER'].get('ignore').split(',')
+
+    def _is_using_default_rcfile(self):
+        return self.rcfile == os.getcwd() + '/' + self.DEFAULT_RCFILE
+
+    def _print_line(self, line):
+        """ Print output only with verbose flag. """
+        if self.verbose:
+            print(line)
+
+    def get_files_from_dir(self, current_dir):
+        """
+        Recursively walk through a directory and get all python files and then walk
+        through any potential directories that are found off current directory,
+        so long as not within self.IGNORE_FOLDERS
+        :return: all python files that were found off current_dir
+        """
+        if current_dir[-1] != "/" and current_dir != ".":
+            current_dir += "/"
+
+        files = []
+
+        for dir_file in os.listdir(current_dir):
+            if current_dir != ".":
+                file_path = current_dir + dir_file
+            else:
+                file_path = dir_file
+
+            if os.path.isfile(file_path):
+                file_split = os.path.splitext(dir_file)
+                if len(file_split) == 2 and file_split[0] != "" \
+                        and file_split[1] == '.py':
+                    files.append(file_path)
+            elif (os.path.isdir(dir_file) or os.path.isdir(file_path)) and dir_file not in self.ignore_folders:
+                path = dir_file + "/"
+                if current_dir != "" and current_dir != ".":
+                    path = current_dir.rstrip("/") + "/" + path
+                files += self.get_files_from_dir(path)
+        return files
+
+    def run(self, output=None, error=None):
+        """ Runs pylint on all python files in the current directory """
+
+        pylint_output = output if output is not None else sys.stdout
+        pylint_error = error if error is not None else sys.stderr
+        savedout, savederr = sys.__stdout__, sys.__stderr__
+        sys.stdout = pylint_output
+        sys.stderr = pylint_error
+
+        pylint_files = self.get_files_from_dir(os.curdir)
+        version = '.'.join([str(x) for x in sys.version_info[0:3]])
+        self._print_line("Using pylint " + colorama.Fore.RED + pylint.__version__ +
+                         colorama.Fore.RESET + " for python " + colorama.Fore.RED +
+                         version + colorama.Fore.RESET)
+
+        self._print_line("pylint running on the following files:")
+        for pylint_file in pylint_files:
+            split_file = pylint_file.split("/")
+            split_file[-1] = colorama.Fore.CYAN + split_file[-1] + colorama.Fore.RESET
+            pylint_file = '/'.join(split_file)
+            self._print_line("- " + pylint_file)
+        self._print_line("----")
+
+        if not self._is_using_default_rcfile():
+            self.args += ['--rcfile={}'.format(self.rcfile)]
+
+        run = pylint.lint.Run(self.args + pylint_files, exit=False)
+
+        sys.stdout = savedout
+        sys.stderr = savederr
+
+        sys.exit(run.linter.msg_status)
 
 
-def runner(output=None, error=None):
-    """
-    Runs pylint on all python files in the current directory
-    """
-
-    pylint_output = output if output is not None else sys.stdout
-    pylint_error = error if error is not None else sys.stderr
-    savedout, savederr = sys.__stdout__, sys.__stderr__
-    sys.stdout = pylint_output
-    sys.stderr = pylint_error
-
-    pylint_files = get_files_from_dir(os.curdir)
-    version = '.'.join([str(x) for x in sys.version_info[0:3]])
-    print("Using pylint " + colorama.Fore.RED + pylint.__version__ +
-          colorama.Fore.RESET + " for python " + colorama.Fore.RED +
-          version + colorama.Fore.RESET)
-    print("pylint running on the following files:")
-    for pylint_file in pylint_files:
-        split_file = pylint_file.split("/")
-        split_file[-1] = colorama.Fore.CYAN + split_file[-1] + colorama.Fore.RESET
-        pylint_file = '/'.join(split_file)
-        print("- " + pylint_file)
-    print("----")
-
-    run = pylint.lint.Run(ARGS + pylint_files, exit=False)
-
-    sys.stdout = savedout
-    sys.stderr = savederr
-
-    sys.exit(run.linter.msg_status)
-
-
-def get_files_from_dir(current_dir):
-    """
-    Recursively walk through a directory and get all python files and then walk
-    through any potential directories that are found off current directory,
-    so long as not within IGNORE_FOLDERS
-    :return: all python files that were found off current_dir
-    """
-    if current_dir[-1] != "/" and current_dir != ".":
-        current_dir += "/"
-    files = []
-    for dir_file in os.listdir(current_dir):
-        if current_dir != ".":
-            file_path = current_dir + dir_file
-        else:
-            file_path = dir_file
-        if os.path.isfile(file_path):
-            file_split = os.path.splitext(dir_file)
-            if len(file_split) == 2 and file_split[0] != "" \
-                    and file_split[1] == '.py':
-                files.append(file_path)
-        elif (os.path.isdir(dir_file) or os.path.isdir(file_path)) and dir_file not in IGNORE_FOLDERS:
-            path = dir_file + "/"
-            if current_dir != "" and current_dir != ".":
-                path = current_dir.rstrip("/") + "/" + path
-            files += get_files_from_dir(path)
-    return files
+def main(output=None, error=None):
+    """ The main (cli) interface for the pylint runner. """
+    runner = Runner()
+    runner.run(output, error)

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup.py
 
 import os
 from pip.req import parse_requirements
+from pip.download import PipSession
 from setuptools import setup
 
 
@@ -15,13 +16,13 @@ def read(*paths):
 
 def get_requirements():
     """Get requirements from requirements.txt file"""
-    install_reqs = parse_requirements("requirements.txt")
+    install_reqs = parse_requirements("requirements.txt", session=PipSession())
     return [str(ir.req) for ir in install_reqs]
 
 
 setup(
     name='pylint_runner',
-    version='0.3.1',
+    version='0.4.0',
     packages=['pylint_runner'],
     url='http://github.com/MasterOdin/pylint_runner',
     license='MIT',
@@ -31,7 +32,7 @@ setup(
     # long_description=open('README.rst').read() + '\n\n' + open('CHANGELOG.rst').read(),
     entry_points={
         'console_scripts': [
-            'pylint_runner = pylint_runner.main:runner',
+            'pylint_runner = pylint_runner.main:main',
         ]
     },
     install_requires=get_requirements(),
@@ -49,6 +50,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5'
     ],
 )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,13 +1,13 @@
-# pylint: disable=missing-docstring,no-value-for-parameter
+# pylint: disable=missing-docstring
 import os
 import pylint_runner.main as runner
-from nose.tools import assert_raises, assert_equal
+from nose.tools import assert_raises, assert_equal, assert_in, assert_true
 
 
 def test_get_files():
     # make sure we use root of pylint_runner module
     os.chdir(os.path.dirname(os.path.realpath(__file__)) + '/../')
-    actual = runner.get_files_from_dir(os.curdir)
+    actual = runner.Runner().get_files_from_dir(os.curdir)
     expected = ['pylint_runner/__init__.py', 'pylint_runner/main.py',
                 'setup.py', 'tests/__init__.py', 'tests/test_runner.py',
                 'tests/tests/dummy.py']
@@ -16,16 +16,40 @@ def test_get_files():
 
 def test_get_files_current_dir():
     path = os.path.dirname(os.path.realpath(__file__))
-    actual = runner.get_files_from_dir(path)
+    actual = runner.Runner().get_files_from_dir(path)
     expected = [path+'/__init__.py', path+'/test_runner.py',
                 path+'/tests/dummy.py']
     _assert_list_equals(expected, actual)
 
 
-def test_runner():
+def test_main():
     with assert_raises(SystemExit) as context_manager:
-        runner.runner(error=open(os.devnull, 'w'))
+        runner.main(error=open(os.devnull, 'w'))
     assert_equal(context_manager.exception.code, 0)
+
+
+def test_rcparser_success():
+
+    with assert_raises(SystemExit) as context_manager:
+        args = ['--rcfile', 'tests/tests/good_rc_file']
+        the_runner = runner.Runner(args=args)
+        the_runner.run(error=open(os.devnull, 'w'))
+    assert_true(context_manager.exception.code > 0)
+    assert_in('migrations', the_runner.ignore_folders)
+
+
+def test_rcparser_failure():
+    with assert_raises(SystemExit) as context_manager:
+        args = ['--rcfile', 'tests/tests/bad_rc_file']
+        runner.Runner(args=args)
+    assert_equal(context_manager.exception.code, 1)
+
+
+def test_rcparser_bad_file():
+    with assert_raises(SystemExit) as context_manager:
+        args = ['--rcfile', 'non-existant-file']
+        runner.Runner(args=args)
+    assert_equal(context_manager.exception.code, 1)
 
 
 def _assert_list_equals(list1, list2):

--- a/tests/tests/bad_rc_file
+++ b/tests/tests/bad_rc_file
@@ -1,0 +1,1 @@
+sldjfasdkjfj

--- a/tests/tests/good_rc_file
+++ b/tests/tests/good_rc_file
@@ -1,0 +1,5 @@
+[MASTER]
+ignore=migrations
+
+[FORMAT]
+max-line-length=15


### PR DESCRIPTION
I refactored the code into a class to more easily parse and store state
from command line arguments.

I added a verbose mode and defaulted it to off (thereby changing the
default output).

I added a `--rcfile` option and a default that will be passed to pylint,
as well as parsing and respecting the ignore setting while building the
file list.

I updated the contents of the readme to support the new features as well
as cleaning up some things like the broken badges.

Finally, I added a changelog.md for kicks and giggles.

With the more extensive changes here, I also included the fix that I put in for #3.
This may or may not close #1 based on the needs there. It now has help text when you run the command with `-h` and the readme is a little more fleshed out, but there isn't more in depth docs for something like https://readthedocs.org

If accepted, this should definitely close #2 and #3. The pylintrc file can now be specified and it shouldn't be too hard to add any other arguments that one might want.