### PR TITLE
Variable exit or do_exit in Run constructor

### DIFF
--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -30,7 +30,7 @@ else:
 PYTHON_VERSION = '.'.join([str(x) for x in sys.version_info[0:3]])
 
 
-class Runner(object):
+class Runner():
     """ A pylint runner that will lint all files recursively from the CWD. """
 
     DEFAULT_IGNORE_FOLDERS = [".git", ".idea", "__pycache__"]
@@ -135,7 +135,7 @@ class Runner(object):
             elif (os.path.isdir(dir_file) or os.path.isdir(file_path))\
                     and dir_file not in self.ignore_folders:
                 path = dir_file + os.path.sep
-                if current_dir != "" and current_dir != ".":
+                if current_dir not in["", "."]:
                     path = os.path.join(current_dir.rstrip(os.path.sep), path)
                 files += self.get_files_from_dir(path)
         return files

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -165,9 +165,9 @@ class Runner():
 
         if not self._is_using_default_rcfile():
             self.args += ['--rcfile={}'.format(self.rcfile)]
-            
+
         exit_kwarg = {'exit': False} if PY2 else {'do_exit': False}
-        
+
         run = pylint.lint.Run(self.args + pylint_files, **exit_kwarg)
         sys.stdout = savedout
         sys.stderr = savederr

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -29,7 +29,7 @@ else:
 
 PYTHON_VERSION = '.'.join([str(x) for x in sys.version_info[0:3]])
 
-class Runner: #pylint: disable=C1001 
+class Runner: #pylint: disable=C1001
     """ A pylint runner that will lint all files recursively from the CWD. """
 
     DEFAULT_IGNORE_FOLDERS = [".git", ".idea", "__pycache__"]

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -166,10 +166,9 @@ class Runner():
         if not self._is_using_default_rcfile():
             self.args += ['--rcfile={}'.format(self.rcfile)]
             
+        exit_kwarg = {'exit': False} if PY2 else {'do_exit': False}
         
-        exit={'exit':False} if PY2 else {'do_exit':False}
-           
-        run = pylint.lint.Run(self.args + pylint_files, **exit)
+        run = pylint.lint.Run(self.args + pylint_files, **exit_kwarg)
         sys.stdout = savedout
         sys.stderr = savederr
 

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -166,10 +166,10 @@ class Runner():
         if not self._is_using_default_rcfile():
             self.args += ['--rcfile={}'.format(self.rcfile)]
             
-        if PY2:
-            run = pylint.lint.Run(self.args + pylint_files, exit=False)
-        else:
-            run = pylint.lint.Run(self.args + pylint_files, do_exit=False)
+        
+        exit={'exit':False} if PY2 else {'do_exit':False}
+           
+        run = pylint.lint.Run(self.args + pylint_files, **exit)
         sys.stdout = savedout
         sys.stderr = savederr
 

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -29,8 +29,7 @@ else:
 
 PYTHON_VERSION = '.'.join([str(x) for x in sys.version_info[0:3]])
 
-
-class Runner:
+class Runner: #pylint: disable=C1001 
     """ A pylint runner that will lint all files recursively from the CWD. """
 
     DEFAULT_IGNORE_FOLDERS = [".git", ".idea", "__pycache__"]

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -30,7 +30,7 @@ else:
 PYTHON_VERSION = '.'.join([str(x) for x in sys.version_info[0:3]])
 
 
-class Runner():
+class Runner:
     """ A pylint runner that will lint all files recursively from the CWD. """
 
     DEFAULT_IGNORE_FOLDERS = [".git", ".idea", "__pycache__"]

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -165,8 +165,11 @@ class Runner():
 
         if not self._is_using_default_rcfile():
             self.args += ['--rcfile={}'.format(self.rcfile)]
-
-        run = pylint.lint.Run(self.args + pylint_files, do_exit=False)
+            
+        if PY2:
+            run = pylint.lint.Run(self.args + pylint_files, exit=False)
+        else:
+            run = pylint.lint.Run(self.args + pylint_files, do_exit=False)
         sys.stdout = savedout
         sys.stderr = savederr
 

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -166,7 +166,7 @@ class Runner(object):
         if not self._is_using_default_rcfile():
             self.args += ['--rcfile={}'.format(self.rcfile)]
 
-        run = pylint.lint.Run(self.args + pylint_files, exit=False)
+        run = pylint.lint.Run(self.args + pylint_files, do_exit=False)
         sys.stdout = savedout
         sys.stderr = savederr
 


### PR DESCRIPTION
Pylint changed the kwargs for Run:
https://github.com/PyCQA/pylint/commit/4210ef9b8c5d9e7b33ff0542683f18b8031193fa#diff-ade2cfcf3e840a993dbd465f517d91f5

Now it takes do_exit instead of exit.