### PR TITLE
fix(bug): TypeError: __init__() got an unexpected keyword argument 'exit'

### DIFF
--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -166,7 +166,7 @@ class Runner(object):
         if not self._is_using_default_rcfile():
             self.args += ['--rcfile={}'.format(self.rcfile)]
 
-        run = pylint.lint.Run(self.args + pylint_files, exit=False)
+        run = pylint.lint.Run(self.args + pylint_files)
         sys.stdout = savedout
         sys.stderr = savederr
 
@@ -177,6 +177,7 @@ def main(output=None, error=None, verbose=False):
     """ The main (cli) interface for the pylint runner. """
     runner = Runner(args=["--verbose"] if verbose is not False else None)
     runner.run(output, error)
+
 
 if __name__ == "__main__":
     main(verbose=True)


### PR DESCRIPTION
### 1. Summary

After my changes I can run pylint_runner.

### 2. Argumentation

See Pylint (:smile:) report for `main.py`:

```text
D:\SashaForks\pylint_runner\pylint_runner>pylint main.py
************* Module pylint_runner.main
main.py:33:0: R0205: Class 'Runner' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
main.py:138:19: R1714: Consider merging these comparisons with "in" to "current_dir not in ('', '.')" (consider-using-in)
main.py:169:14: E1123: Unexpected keyword argument 'exit' in constructor call (unexpected-keyword-arg)

-----------------------------------
Your code has been rated at 9.32/10
```

### 3. Steps to reproduce

I install pylint_runner via PyPI → in any directory with Python files I run:

```text
pylint_runner -v
```

### 4. Behavior before pull request

```python
D:\Erichek\erichek>pylint_runner -v
Using pylint 2.1.1 for python 3.7.0
pylint running on the following files:
- eric_body.py
- eric_config.py
- eric_encoding.py
- eric_eyo.py
- eric_head.py
- eric_regex.py
- eric_summary.py
- __init__.py
- __main__.py
----
Traceback (most recent call last):
  File "c:\python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Python37\Scripts\pylint_runner.exe\__main__.py", line 9, in <module>
  File "c:\python37\lib\site-packages\pylint_runner\main.py", line 179, in main
    runner.run(output, error)
  File "c:\python37\lib\site-packages\pylint_runner\main.py", line 169, in run
    run = pylint.lint.Run(self.args + pylint_files, exit=False)
TypeError: __init__() got an unexpected keyword argument 'exit'
```

### 5. Behavior after pull request

```python
D:\Erichek\erichek>pylint_runner -v
Using pylint 2.1.1 for python 3.7.0
pylint running on the following files:
- eric_body.py
- eric_config.py
- eric_encoding.py
- eric_eyo.py
- eric_head.py
- eric_regex.py
- eric_summary.py
- __init__.py
- __main__.py
----

-------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 9.92/10, +0.08)
```

### 6. Testing environment

+ Windows 10 Enterprise LTSB 64-bit EN
+ Python 3.7.0
+ Pylint 2.1.1
+ pylint_runner 0.5.3

Thanks.