### PR TITLE
Support setup.cfg

### DIFF
--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -112,11 +112,11 @@ class Runner:
             print(error_message)
             sys.exit(1)
 
-    master_sections = ['MASTER', 'master', 'pylint.MASTER', 'pylint.master']
-    for master_section in master_sections:
-        if config.has_section(master_section) and config.get(master_section, "ignore"):
-            self.ignore_folders += config.get(master_section, "ignore").split(",")
-            break
+        master_sections = ['MASTER', 'master', 'pylint.MASTER', 'pylint.master']
+        for master_section in master_sections:
+            if config.has_section(master_section) and config.get(master_section, "ignore"):
+                self.ignore_folders += config.get(master_section, "ignore").split(",")
+                break
 
     def _is_using_default_rcfile(self):
         return self.rcfile == os.getcwd() + "/" + self.DEFAULT_RCFILE

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -112,8 +112,11 @@ class Runner:
             print(error_message)
             sys.exit(1)
 
-        if config.has_section("MASTER") and config.get("MASTER", "ignore"):
-            self.ignore_folders += config.get("MASTER", "ignore").split(",")
+    master_sections = ['MASTER', 'master', 'pylint.MASTER', 'pylint.master']
+    for master_section in master_sections:
+        if config.has_section(master_section) and config.get(master_section, "ignore"):
+            self.ignore_folders += config.get(master_section, "ignore").split(",")
+            break
 
     def _is_using_default_rcfile(self):
         return self.rcfile == os.getcwd() + "/" + self.DEFAULT_RCFILE


### PR DESCRIPTION
In order to differentiate between sections for different tools in the increasingly common `setup.cfg` file, Pylint sections are prefaced with `pylint.`, which breaks `pylint_runner`'s parsing of ignored files and directories. This change fixes that. I've also noticed some people using lowercase `master` to in their configuration files, so this adds supports upper and lowercase `MASTER` sections as well.