### PR TITLE
Use pylint config parser for pyproject.toml and setup.cfg support

### DIFF
--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -32,7 +32,7 @@ class Runner:
         colorama.init(autoreset=True)
 
         self.verbose = False
-        self.args = self.DEFAULT_ARGS
+        self.args = list(self.DEFAULT_ARGS)
         self.rcfile = self.DEFAULT_RCFILE
         self.ignore_folders = self.DEFAULT_IGNORE_FOLDERS
 

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -105,7 +105,7 @@ class Runner:
             sys.exit(1)
 
         config = linter.cfgfile_parser
-        if config.has_section("MASTER") and config.get("MASTER", "ignore"):
+        if config.has_option("MASTER", "ignore"):
             self.ignore_folders += config.get("MASTER", "ignore").split(",")
 
     def _print_line(self, line):

--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -106,7 +106,12 @@ class Runner:
 
         config = linter.cfgfile_parser
         if config.has_option("MASTER", "ignore"):
-            self.ignore_folders += config.get("MASTER", "ignore").split(",")
+            self.ignore_folders += [
+                word.strip()
+                for word
+                in config.get("MASTER", "ignore").split(",")
+                if word.strip()
+            ]
 
     def _print_line(self, line):
         """ Print output only with verbose flag. """

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -69,8 +69,6 @@ def _assert_list_equals(list1, list2):
 def test_passthrough_args():
     the_runner = runner.Runner(args=['-d', 'C0103', '-d', 'E0602'])
     expected = [
-        '--rcfile=tests/tests/good_rc_file',
-        '--rcfile=.pylintrc',
         '--reports=n',
         '--output-format=colorized',
         '-d',

--- a/tests/tests/good_rc_file
+++ b/tests/tests/good_rc_file
@@ -2,4 +2,4 @@
 ignore=migrations
 
 [FORMAT]
-max-line-length=15
+max-line-length=100


### PR DESCRIPTION
Pylint 2.5.0 and later support reading configuration from `pyproject.toml` or `setup.cfg` if `pylintrc` and `.pylintrc` do not exist.  (PyCQA/pylint#3169)  In order to support these configuration files, this PR changes pylint_runner to use `pylint.lint.pylinter.PyLinter#read_config_file()` instead of `configparser.ConfigParser#read()` to read the pylint configuration.

It also adds a check to avoid `configparser.NoOptionError` if `ignore` is not configured and to strip whitespace from `ignore` values as pylint does.  If you would prefer these to be moved to a separate PR, let me know.

Thanks,
Kevin