### PR TITLE
Fix crash and pylint errors

### DIFF
--- a/pylint_runner/main.py
+++ b/pylint_runner/main.py
@@ -68,10 +68,7 @@ class Runner:
             "-V",
             "--version",
             action="version",
-            version="%(prog)s ({0}) for Python {1}".format(
-                __version__,
-                PYTHON_VERSION
-            ),
+            version=f"%(prog)s ({__version__}) for Python {PYTHON_VERSION}",
         )
 
         options, rest = parser.parse_known_args(args)
@@ -92,9 +89,7 @@ class Runner:
 
         error_message = (
             colorama.Fore.RED
-            + "{} does not appear to be a valid pylintrc file".format(
-                self.rcfile
-            )
+            + f"{self.rcfile} does not appear to be a valid pylintrc file"
             + colorama.Fore.RESET
         )
 
@@ -190,9 +185,10 @@ class Runner:
         if not self._is_using_default_rcfile():
             # insert this at the front so it's not after any potential
             # positional arguments
-            self.args.insert(0, "--rcfile={}".format(self.rcfile))
+            self.args.insert(0, f"--rcfile={self.rcfile}")
 
-        pylint_version = [int(x) for x in pylint.__version__.split('.')]
+        #strip out -dev in case not on prod version of pylint
+        pylint_version = [int(x) for x in pylint.__version__.replace('-dev', '').split('.')]
 
         pylint_5 = pylint_version[1] == 5 and pylint_version[2] < 1
         pylint_pre_5 = pylint_version[1] < 5

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ def get_requirements():
 
 CONSOLE_SCRIPTS = [
     "pylint_runner = pylint_runner.main:main",
-    "pylint_runner{0} = pylint_runner.main:main".format(MAJOR_VERSION),
-    "pylint_runner{0} = pylint_runner.main:main".format(MAJOR_MINOR_VERSION),
+    f"pylint_runner{MAJOR_VERSION} = pylint_runner.main:main",
+    f"pylint_runner{MAJOR_MINOR_VERSION} = pylint_runner.main:main",
 ]
 
 DESC = "Run pylint recursively on all py files in current and sub-directories"


### PR DESCRIPTION
When the system pylint version ends in -dev it causes pylint_runner to crash. Fixed. Also remedied the few pylint warnings given on the project.